### PR TITLE
use alpine 3.4 and bosun 0.5.0-rc4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:edge
+FROM alpine:3.4
 
 RUN apk --update add rsyslog bash wget
 RUN apk --update add --virtual builddeps build-base git go
 
-ENV BOSUN_VERSION 0.5.0-rc3
+ENV BOSUN_VERSION 0.5.0-rc4
 ENV GOPATH /tmp/bosun
 
 RUN mkdir -p /opt/bosun/bin ${GOPATH}/src/


### PR DESCRIPTION
Hi,

this pull request updates the image to `alpine:3.4` and also the version of bosun to `0.5.0-rc4`. I've built and tested the image with an existing bosun deployment based on your [gist](https://gist.github.com/lukaspustina/a04f66461c72f8adc92f6283c1c4c6a0) with an additional redis container.

I would really appreciate the merge and docker hub update of your image.

Cheers,
ubergesundheit
